### PR TITLE
Draft: Use wild to get globs from windows command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,14 @@ dependencies = [
  "serde_derive",
  "tempfile",
  "toml",
+ "wild",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
@@ -743,6 +750,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "wild"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3131afc8c575281e1e80f36ed6a092aa502c08b18ed7524e86fbbb12bb410e1"
+dependencies = [
+ "glob",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde = "1.0.197"
 serde_derive = "1.0.197"
 toml = "0.8.11"
 openssl = { version = "0.10", features = ["vendored"] }
+wild = "2.2.1"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ I suggest adding a shorter shell alias to save typing. Perhaps `gm` for git many
 ```sh
 cd ~/repos/
 gitopolis add *
+
+# (or in windows command-line):
+gitopolis add */
 ```
 
 ### Running shell / git commands in many repos

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn main() {
 		.filter(None, LevelFilter::Info) // turn on log output
 		.init();
 
-	match &Args::parse().command {
+	match &Args::parse_from(wild::args()).command {
 		Some(Commands::Add { repo_folders }) => add(repo_folders.to_owned()),
 		Some(Commands::Remove { repo_folders }) => {
 			init_gitopolis()


### PR DESCRIPTION
I wanted to make 'gitopolis add \*' work in cmd. It's my default terminal, so I often am not using git bash when I want to call gitopolis. "\*" however depends on bash globing, so here is the change to support that. It also means powershell will work as well.

I don't know how you want to manage contributions, but here is, it seems useful to me.
 
 No test automation. I guess the end to end tests could us cmd.exe (?), but I'm not sure the juice is worth the squeeze. 
I have checked things like `gitopolis exec -- git add *.txt` and it seems fine.