### PR TITLE
OSX support 2

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -6,7 +6,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build-linux:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -23,15 +23,84 @@ jobs:
         sed -i "s/0\\.0\\.0-git/${RELEASE_TAG##*\/v}/" Cargo.lock
     - name: Build-linux
       run: cross build --target x86_64-unknown-linux-gnu --release
-    - name: Build-win
-      run: cross build --target x86_64-pc-windows-gnu --release
     - name: Package Linux
       run: tar -czvf gitopolis-linux-x86_64.tar.gz -C target/x86_64-unknown-linux-gnu/release/ gitopolis
+    - name: Upload Linux Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: gitopolis-linux-x86_64
+        path: gitopolis-linux-x86_64.tar.gz
+
+  build-windows:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup
+      run: cargo install -f cross
+    - name: Version
+      shell: bash
+      env:
+        RELEASE_TAG: ${{ github.ref }}
+      run: |
+        sed -i "s/0\\.0\\.0-git/${RELEASE_TAG##*\/v}/" Cargo.toml
+        sed -i "s/0\\.0\\.0-git/${RELEASE_TAG##*\/v}/" Cargo.lock
+    - name: Build-win
+      run: cross build --target x86_64-pc-windows-gnu --release
     - name: Package Windows
       run: zip gitopolis-windows-x86_64.zip target/x86_64-pc-windows-gnu/release/gitopolis.exe
+    - name: Upload Windows Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: gitopolis-windows-x86_64
+        path: gitopolis-windows-x86_64.zip
+
+  build-osx:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Version
+      shell: bash
+      env:
+        RELEASE_TAG: ${{ github.ref }}
+      run: |
+        sed -i '' "s/0\\.0\\.0-git/${RELEASE_TAG##*\/v}/" Cargo.toml
+        sed -i '' "s/0\\.0\\.0-git/${RELEASE_TAG##*\/v}/" Cargo.lock
+    - name: Build-osx
+      run: |
+        rustup target add x86_64-apple-darwin
+        cargo build --target x86_64-apple-darwin --release
+    - name: Package OSX
+      run: zip gitopolis-osx-x86_64.zip target/x86_64-apple-darwin/release/gitopolis
+    - name: Upload OSX Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: gitopolis-osx-x86_64
+        path: gitopolis-osx-x86_64.zip
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [build-linux, build-windows, build-osx]
+    steps:
+    - name: Download Linux Artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: gitopolis-linux-x86_64
+        path: .
+    - name: Download Windows Artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: gitopolis-windows-x86_64
+        path: .
+    - name: Download OSX Artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: gitopolis-osx-x86_64
+        path: .
     - name: Publish
       uses: ncipollo/release-action@v1
       if: startsWith(github.ref, 'refs/tags/v')
       with:
-        artifacts: gitopolis-linux-x86_64.tar.gz,gitopolis-windows-x86_64.zip
+        artifacts: gitopolis-linux-x86_64.tar.gz,gitopolis-windows-x86_64.zip,gitopolis-osx-x86_64.zip
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -38,7 +38,10 @@ fn repo_exec(path: &str, cmd: &str, args: &Vec<String>) -> Result<ExitStatus, Er
 
 	let exit_code = &child_process.wait()?;
 	if !exit_code.success() {
-		eprintln!("Command exited with code {}", exit_code.code().expect("exit code missing"));
+		eprintln!(
+			"Command exited with code {}",
+			exit_code.code().expect("exit code missing")
+		);
 	}
 	Ok(*exit_code)
 }

--- a/tests/end_to_end_tests.rs
+++ b/tests/end_to_end_tests.rs
@@ -376,9 +376,7 @@ fn exec_non_zero() {
 		.assert()
 		.success()
 		.stdout(expected_stdout)
-		.stderr(predicate::str::contains(
-			"2 commands exited with non-zero status code",
-		));
+		.stderr(predicate::str::contains("No such file or directory"));
 }
 
 #[test]

--- a/tests/end_to_end_tests.rs
+++ b/tests/end_to_end_tests.rs
@@ -609,7 +609,20 @@ done.
 		.stdout(expected_clone_stdout);
 
 	// check repo has been successfully cloned by running a git command on it via exec
-	let expected_exec_stdout = "
+	let expected_exec_stdout = match get_operating_system() {
+		OperatingSystem::MacOSX => {
+			"
+🏢 some_git_folder> git status
+On branch master
+
+No commits yet
+
+nothing to commit
+
+"
+		}
+		OperatingSystem::Other => {
+			"
 🏢 some_git_folder> git status
 On branch master
 
@@ -617,7 +630,9 @@ No commits yet
 
 nothing to commit (create/copy files and use \"git add\" to track)
 
-";
+"
+		}
+	};
 
 	gitopolis_executable()
 		.current_dir(&temp)
@@ -673,7 +688,20 @@ done.
 		.stdout(expected_clone_stdout);
 
 	// check repo has been successfully cloned by running a git command on it via exec
-	let expected_exec_stdout = "
+	let expected_exec_stdout = match get_operating_system() {
+		OperatingSystem::MacOSX => {
+			"
+🏢 some_git_folder> git status
+On branch master
+
+No commits yet
+
+nothing to commit
+
+"
+		}
+		OperatingSystem::Other => {
+			"
 🏢 some_git_folder> git status
 On branch master
 
@@ -681,7 +709,9 @@ No commits yet
 
 nothing to commit (create/copy files and use \"git add\" to track)
 
-";
+"
+		}
+	};
 	gitopolis_executable()
 		.current_dir(&temp)
 		.args(vec!["exec", "--tag", "some_tag", "--", "git", "status"]) // filter exec to tag otherwise it runs on repos that don't yet exists https://github.com/timabell/gitopolis/issues/29

--- a/tests/end_to_end_tests.rs
+++ b/tests/end_to_end_tests.rs
@@ -14,7 +14,8 @@ fn help() {
 		.stdout(predicate::str::contains("Usage: gitopolis"));
 }
 
-#[cfg(target_os = "windows")] // only windows (cmd/powerhell) needs to have globs expanded for it, real OS's do it for you in the shell
+// only windows (cmd/powerhell) needs to have globs expanded for it, real OS's do it for you in the shell
+#[cfg(target_os = "windows")]
 #[test]
 fn add_glob() {
 	// Linux has shell globbing built in, but that's not available for windows/cmd so "add *" is passed
@@ -372,7 +373,7 @@ fn exec_non_zero() {
 ";
 	let expected_stderr = match get_operating_system() {
 		OperatingSystem::MacOSX => {
-"ls: non-existent: No such file or directory
+			"ls: non-existent: No such file or directory
 Command exited with code 1
 ls: non-existent: No such file or directory
 Command exited with code 1

--- a/tests/end_to_end_tests.rs
+++ b/tests/end_to_end_tests.rs
@@ -609,12 +609,22 @@ done.
 		.stdout(expected_clone_stdout);
 
 	// check repo has been successfully cloned by running a git command on it via exec
+	let expected_exec_stdout = "
+🏢 some_git_folder> git status
+On branch master
+
+No commits yet
+
+nothing to commit (create/copy files and use \"git add\" to track)
+
+";
+
 	gitopolis_executable()
 		.current_dir(&temp)
 		.args(vec!["exec", "--", "git", "status"])
 		.assert()
 		.success()
-		.stdout(predicate::str::contains("nothing to commit"));
+		.stdout(expected_exec_stdout);
 }
 
 #[test]
@@ -663,12 +673,21 @@ done.
 		.stdout(expected_clone_stdout);
 
 	// check repo has been successfully cloned by running a git command on it via exec
+	let expected_exec_stdout = "
+🏢 some_git_folder> git status
+On branch master
+
+No commits yet
+
+nothing to commit (create/copy files and use \"git add\" to track)
+
+";
 	gitopolis_executable()
 		.current_dir(&temp)
 		.args(vec!["exec", "--tag", "some_tag", "--", "git", "status"]) // filter exec to tag otherwise it runs on repos that don't yet exists https://github.com/timabell/gitopolis/issues/29
 		.assert()
 		.success()
-		.stdout(predicate::str::contains("nothing to commit"));
+		.stdout(expected_exec_stdout);
 }
 
 fn create_local_repo(temp: &TempDir, repo_name: &str) {

--- a/tests/end_to_end_tests.rs
+++ b/tests/end_to_end_tests.rs
@@ -369,12 +369,6 @@ fn exec_non_zero() {
 🏢 some_other_git_folder> ls non-existent
 
 ";
-	let expected_stderr = "ls: cannot access \'non-existent\': No such file or directory
-Command exited with code 2
-ls: cannot access \'non-existent\': No such file or directory
-Command exited with code 2
-2 commands exited with non-zero status code
-";
 
 	gitopolis_executable()
 		.current_dir(&temp)
@@ -382,7 +376,9 @@ Command exited with code 2
 		.assert()
 		.success()
 		.stdout(expected_stdout)
-		.stderr(expected_stderr);
+		.stderr(predicate::str::contains(
+			"2 commands exited with non-zero status code",
+		));
 }
 
 #[test]
@@ -595,22 +591,12 @@ done.
 		.stdout(expected_clone_stdout);
 
 	// check repo has been successfully cloned by running a git command on it via exec
-	let expected_exec_stdout = "
-🏢 some_git_folder> git status
-On branch master
-
-No commits yet
-
-nothing to commit (create/copy files and use \"git add\" to track)
-
-";
-
 	gitopolis_executable()
 		.current_dir(&temp)
 		.args(vec!["exec", "--", "git", "status"])
 		.assert()
 		.success()
-		.stdout(expected_exec_stdout);
+		.stdout(predicate::str::contains("nothing to commit"));
 }
 
 #[test]
@@ -659,21 +645,12 @@ done.
 		.stdout(expected_clone_stdout);
 
 	// check repo has been successfully cloned by running a git command on it via exec
-	let expected_exec_stdout = "
-🏢 some_git_folder> git status
-On branch master
-
-No commits yet
-
-nothing to commit (create/copy files and use \"git add\" to track)
-
-";
 	gitopolis_executable()
 		.current_dir(&temp)
 		.args(vec!["exec", "--tag", "some_tag", "--", "git", "status"]) // filter exec to tag otherwise it runs on repos that don't yet exists https://github.com/timabell/gitopolis/issues/29
 		.assert()
 		.success()
-		.stdout(expected_exec_stdout);
+		.stdout(predicate::str::contains("nothing to commit"));
 }
 
 fn create_local_repo(temp: &TempDir, repo_name: &str) {


### PR DESCRIPTION
My variant of #134 

- Split github action builds into parallel per-OS builds
- Add OSX build & release
- Handle variation in error output on osx in tests
- Sets tag version in cargo.toml before building release

![shutter_20245-29_06](https://github.com/rustworkshop/gitopolis/assets/19378/7bc247c5-6a49-421c-a007-d3f9a7aad445)

Code contributions from @peteringram0 and @NathanLBCooper 
